### PR TITLE
Add HTTPS support

### DIFF
--- a/Freenas/private/Set-FreeNasCipherSSL.ps1
+++ b/Freenas/private/Set-FreeNasCipherSSL.ps1
@@ -1,0 +1,7 @@
+function Set-FreeNasCipherSSL {
+
+    # Hack for allowing TLS 1.1 and TLS 1.2 (by default it is only SSL3 and TLS (1.0))
+    $AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
+    [System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
+
+}

--- a/Freenas/private/Set-FreeNasUntrustedSSL.ps1
+++ b/Freenas/private/Set-FreeNasUntrustedSSL.ps1
@@ -1,0 +1,18 @@
+function Set-FreeNasUntrustedSSL {
+
+    # Hack for allowing untrusted SSL certs with https connections
+    Add-Type -TypeDefinition @"
+    using System.Net;
+    using System.Security.Cryptography.X509Certificates;
+    public class TrustAllCertsPolicy : ICertificatePolicy {
+        public bool CheckValidationResult(
+        ServicePoint srvPoint, X509Certificate certificate,
+        WebRequest request, int certificateProblem) {
+            return true;
+        }
+    }
+"@
+
+    [System.Net.ServicePointManager]::CertificatePolicy = New-Object -TypeName TrustAllCertsPolicy
+
+}

--- a/Freenas/private/Show-FreeNasException.ps1
+++ b/Freenas/private/Show-FreeNasException.ps1
@@ -5,6 +5,16 @@ function Show-FreeNasException() {
         $Exception
     )
 
+    #Check if certificate is valid
+    if ($Exception.Exception.InnerException) {
+        $exceptiontype = $Exception.Exception.InnerException.GetType()
+        if ("AuthenticationException" -eq $exceptiontype.name) {
+            Write-Warning "Invalid certificat (Untrusted, wrong date, invalid name...)"
+            Write-Warning "Try to use Connect-FreeNasServer -SkipCertificateCheck for connection"
+            throw "Unable to connect (certificate)"
+        }
+    }
+
     If ($Exception.Exception.Response) {
         if ("Desktop" -eq $PSVersionTable.PSEdition) {
             $result = $Exception.Exception.Response.GetResponseStream()

--- a/Freenas/public/Connect-FreeNasServer.ps1
+++ b/Freenas/public/Connect-FreeNasServer.ps1
@@ -65,6 +65,12 @@
             if (!$port) {
                 $port = 443
             }
+            #for PowerShell (<=) 5 (Desktop), Enable TLS 1.1, 1.2
+            if ("Desktop" -eq $PSVersionTable.PsEdition) {
+                #Enable TLS 1.1 and 1.2
+                Set-FreeNasCipherSSL
+
+            }
             $uri = "https://${Server}:${port}/api/v1.0/system/version/"
         }
 

--- a/Freenas/public/Connect-FreeNasServer.ps1
+++ b/Freenas/public/Connect-FreeNasServer.ps1
@@ -17,6 +17,8 @@
         [Parameter(Mandatory = $false)]
         [PSCredential]$Credentials,
         [Parameter(Mandatory = $false)]
+        [switch]$httpOnly = $false,
+        [Parameter(Mandatory = $false)]
         [ValidateRange(1, 65535)]
         [int]$port
     )
@@ -52,12 +54,22 @@
         $script:headers = @{ Authorization = "Basic " + $base64; "Content-type" = "application/json" }
         $script:invokeParams = @{ UseBasicParsing = $true }
 
-        if (!$port) {
-            $port = 80
-        }
-        $script:port = $port
+        if ($httpOnly) {
+            if (!$port) {
+                $port = 80
+            }
 
-        $uri = "http://${Server}:${port}/api/v1.0/system/version/"
+            $uri = "http://${Server}:${port}/api/v1.0/system/version/"
+        }
+        else {
+            if (!$port) {
+                $port = 443
+            }
+            $uri = "https://${Server}:${port}/api/v1.0/system/version/"
+        }
+
+        $script:port = $port
+        $script:httpOnly = $httpOnly
 
         try {
             $result = Invoke-RestMethod -Uri $uri -Method Get -SessionVariable Freenas_S -headers $headers @invokeParams

--- a/Freenas/public/Invoke-FreeNasRestMethod.ps1
+++ b/Freenas/public/Invoke-FreeNasRestMethod.ps1
@@ -35,7 +35,7 @@ function Invoke-FreeNasRestMethod
 
         if ($null -eq $Script:SrvFreenas)
         {
-            Throw "Not Connected. Connect to the FreeNas with Connect-FreeNas"
+            Throw "Not Connected. Connect to the FreeNas with Connect-FreeNasServer"
         }
 
         $Server = $Script:SrvFreenas

--- a/Freenas/public/Invoke-FreeNasRestMethod.ps1
+++ b/Freenas/public/Invoke-FreeNasRestMethod.ps1
@@ -42,8 +42,14 @@ function Invoke-FreeNasRestMethod
         $sessionvariable = $Script:Session
         $headers = $Script:Headers
         $invokeParams = $Script:invokeParams
+        $httpOnly = $Script:httpOnly
 
-        $fullurl = "http://${Server}:${port}/${uri}"
+        if ($httpOnly) {
+            $fullurl = "http://${Server}:${port}/${uri}"
+        }
+        else {
+            $fullurl = "https://${Server}:${port}/${uri}"
+        }
 
         try
         {

--- a/Freenas/public/Invoke-FreeNasRestMethod.ps1
+++ b/Freenas/public/Invoke-FreeNasRestMethod.ps1
@@ -43,6 +43,7 @@ function Invoke-FreeNasRestMethod
         $headers = $Script:Headers
         $invokeParams = $Script:invokeParams
         $httpOnly = $Script:httpOnly
+        $port = $Script:port
 
         if ($httpOnly) {
             $fullurl = "http://${Server}:${port}/${uri}"


### PR DESCRIPTION
Add HTTPS support (enabled by default)

If the certificate is not valid (or self signed) need to use -SkipCertificateCheck to Connect-FreeNasServer
If the HTTPS is not enable on FreeNas, need to use -httpOnly

Tested with PowerShell 5 and 6 (Core)

Fix #5  