### PR TITLE
Add release workflow for Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+name: Release
+
+on: [release]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish
+      run: |
+        pwsh -Command "Publish-Module -Path ./Freenas -NuGetApiKey ${{ secrets.PSGALLERY_API_KEY }}"


### PR DESCRIPTION
When release a new release on github, push this new release on PS Gallery

Need to configure PSGALLERY_API_KEY secret on Github Repo Settings