### PR TITLE
Remove Format-List from output

### DIFF
--- a/Freenas/public/Connect-FreeNasServer.ps1
+++ b/Freenas/public/Connect-FreeNasServer.ps1
@@ -84,7 +84,7 @@ function Connect-FreeNasServer
         #If there is a password (and a user), create a credentials
         if ($Password)
         {
-            $Credentials = New-Object -TypeName System.Management.Automation.PSCredential($Username, $Password)
+            $Credentials = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $Username, $Password
         }
         #Not Credentials (and no password)
         if ($NULL -eq $Credentials)

--- a/Freenas/public/Connect-FreeNasServer.ps1
+++ b/Freenas/public/Connect-FreeNasServer.ps1
@@ -84,7 +84,7 @@ function Connect-FreeNasServer
         #If there is a password (and a user), create a credentials
         if ($Password)
         {
-            $Credentials = New-Object System.Management.Automation.PSCredential($Username, $Password)
+            $Credentials = New-Object -TypeName System.Management.Automation.PSCredential($Username, $Password)
         }
         #Not Credentials (and no password)
         if ($NULL -eq $Credentials)
@@ -121,12 +121,12 @@ function Connect-FreeNasServer
             #for PowerShell (<=) 5 (Desktop), Enable TLS 1.1, 1.2 and Disable SSL chain trust
             if ("Desktop" -eq $PSVersionTable.PsEdition)
             {
-                Write-Verbose "Desktop Version try to Enable TLS 1.1 and 1.2"
+                Write-Verbose -Message "Desktop Version try to Enable TLS 1.1 and 1.2"
                 #Enable TLS 1.1 and 1.2
                 Set-FreeNasCipherSSL
                 if ($SkipCertificateCheck)
                 {
-                    Write-Verbose "Disable SSL chain trust"
+                    Write-Verbose -Message "Disable SSL chain trust"
 
                     #Disable SSL chain trust...
                     Set-FreeNasuntrustedSSL
@@ -154,7 +154,7 @@ function Connect-FreeNasServer
             throw "Unable to get data"
         }
 
-        Write-Host "Welcome on"$result.name"-"$result.fullversion""
+        Write-Host -Object "Welcome on"$result.name"-"$result.fullversion""
 
         $Script:Session = $Freenas_S
 

--- a/Freenas/public/Get-FreeNasCertificate.ps1
+++ b/Freenas/public/Get-FreeNasCertificate.ps1
@@ -60,12 +60,12 @@ function Get-FreeNasCertificate
 
         $result = Invoke-FreeNasRestMethod -Uri $Uri -Method Get
 
-        $Certificate = New-Object System.Collections.ArrayList
+        $Certificate = New-Object -TypeName System.Collections.ArrayList
 
         if ($null -eq $result.count)
         {
 
-            $temp = New-Object System.Object
+            $temp = New-Object -TypeName System.Object
             $temp | Add-Member -MemberType NoteProperty -Name "Name" -Value "$($result.cert_name)"
             $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value "$($result.id)"
             $temp | Add-Member -MemberType NoteProperty -Name "CSR" -Value "$($result.cert_CSR)"
@@ -100,7 +100,7 @@ function Get-FreeNasCertificate
             for ($i = 0; $i -lt $result.Count; $i++)
             {
 
-                $temp = New-Object System.Object
+                $temp = New-Object -TypeName System.Object
                 $temp | Add-Member -MemberType NoteProperty -Name "Name" -Value "$($result[$i].cert_name)"
                 $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value "$($result[$i].id)"
                 $temp | Add-Member -MemberType NoteProperty -Name "CSR" -Value "$($result[$i].cert_CSR)"

--- a/Freenas/public/Get-FreeNasDisk.ps1
+++ b/Freenas/public/Get-FreeNasDisk.ps1
@@ -36,7 +36,7 @@ function Get-FreeNasDisk
     {
         $Name = ($disk.disk_name)
         $Size_GB = ([Math]::Round($disk.disk_size / 1024 / 1024 / 1024, 2))
-        Write-Verbose " Find the disk $name with the size $Size_GB"
+        Write-Verbose -Message " Find the disk $name with the size $Size_GB"
         [PSCustomObject]@{
             Name    = ($disk.disk_name)
             Size_GB = ([Math]::Round($disk.disk_size / 1024 / 1024 / 1024, 2))

--- a/Freenas/public/Get-FreeNasIscsiAssociat2Extent.ps1
+++ b/Freenas/public/Get-FreeNasIscsiAssociat2Extent.ps1
@@ -25,10 +25,10 @@
         {
             'Id'
             {
-                $FreenasIscsiAssociat2Extent = New-Object System.Collections.ArrayList
+                $FreenasIscsiAssociat2Extent = New-Object -TypeName System.Collections.ArrayList
                 for ($i = 0; $i -lt $result.Count; $i++)
                 {
-                    $temp = New-Object System.Object
+                    $temp = New-Object -TypeName System.Object
                     $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value "$($result[$i].Id)"
                     $temp | Add-Member -MemberType NoteProperty -Name "Iscsi_Extent_Id" -Value "$($result[$i].iscsi_extent)"
                     $temp | Add-Member -MemberType NoteProperty -Name "Iscsi_LunId" -Value "$($result[$i].iscsi_lunid)"
@@ -39,7 +39,7 @@
             }
             'Name'
             {
-                $FreenasIscsiAssociat2Extent = New-Object System.Collections.ArrayList
+                $FreenasIscsiAssociat2Extent = New-Object -TypeName System.Collections.ArrayList
                 for ($i = 0; $i -lt $result.Count; $i++)
                 {
                     $value = $result[$i].iscsi_extent
@@ -66,7 +66,7 @@
                     }
 
 
-                    $temp = New-Object System.Object
+                    $temp = New-Object -TypeName System.Object
                     $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value "$($result[$i].Id)"
                     $temp | Add-Member -MemberType NoteProperty -Name "Iscsi_Extent_Name" -Value $IscsiExtendF
                     $temp | Add-Member -MemberType NoteProperty -Name "LUN Id" -Value "$($result[$i].iscsi_lunid)"

--- a/Freenas/public/Get-FreeNasIscsiConf.ps1
+++ b/Freenas/public/Get-FreeNasIscsiConf.ps1
@@ -18,7 +18,7 @@
     {
         $IscsiConf = New-Object -TypeName System.Collections.ArrayList
 
-        $temp = New-Object PSObject
+        $temp = New-Object -TypeName PSObject
         $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value $result.id
         $temp | Add-Member -MemberType NoteProperty -Name "Base Name" -Value $result.iscsi_basename
         $temp | Add-Member -MemberType NoteProperty -Name "ISNS Server" -Value $result.iscsi_isns_servers

--- a/Freenas/public/Get-FreeNasIscsiConf.ps1
+++ b/Freenas/public/Get-FreeNasIscsiConf.ps1
@@ -16,7 +16,7 @@
     }
     End
     {
-        $IscsiConf = New-Object System.Collections.ArrayList
+        $IscsiConf = New-Object -TypeName System.Collections.ArrayList
 
         $temp = New-Object PSObject
         $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value $result.id

--- a/Freenas/public/Get-FreeNasIscsiConf.ps1
+++ b/Freenas/public/Get-FreeNasIscsiConf.ps1
@@ -26,6 +26,6 @@
 
         $IscsiConf.Add($temp) | Out-Null
 
-        return $IscsiConf | fl
+        return $IscsiConf
     }
 }

--- a/Freenas/public/Get-FreeNasIscsiExtent.ps1
+++ b/Freenas/public/Get-FreeNasIscsiExtent.ps1
@@ -14,7 +14,7 @@
         $Uri = "api/v1.0/services/iscsi/extent/"
         $result = Invoke-FreeNasRestMethod -Uri $Uri -Method Get
 
-        $Extent = New-Object System.Collections.ArrayList
+        $Extent = New-Object -TypeName System.Collections.ArrayList
 
         if ($null -eq $result.Count)
         {
@@ -39,7 +39,7 @@
                 }
             }
             Catch { throw }
-            $temp = New-Object System.Object
+            $temp = New-Object -TypeName System.Object
             $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value  "$($result.id)"
             $temp | Add-Member -MemberType NoteProperty -Name "Extent_Type" -Value "$($result.iscsi_target_extent_type)"
             $temp | Add-Member -MemberType NoteProperty -Name "Extent_Name" -Value  "$($result.iscsi_target_extent_name)"
@@ -76,7 +76,7 @@
                     }
                 }
                 Catch { throw }
-                $temp = New-Object System.Object
+                $temp = New-Object -TypeName System.Object
                 $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value  "$($result[$i].id)"
                 $temp | Add-Member -MemberType NoteProperty -Name "Extent_Type" -Value "$($result[$i].iscsi_target_extent_type)"
                 $temp | Add-Member -MemberType NoteProperty -Name "Extent_Name" -Value  "$($result[$i].iscsi_target_extent_name)"

--- a/Freenas/public/Get-FreeNasIscsiInitiator.ps1
+++ b/Freenas/public/Get-FreeNasIscsiInitiator.ps1
@@ -14,9 +14,9 @@
 
         $result = Invoke-FreeNasRestMethod -Uri $Uri -Method Get
 
-        $Obj = New-Object System.Collections.ArrayList
+        $Obj = New-Object -TypeName System.Collections.ArrayList
 
-        $temp = New-Object System.Object
+        $temp = New-Object -TypeName System.Object
         $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value $result.id
         $temp | Add-Member -MemberType NoteProperty -Name "Initiator" -Value $result.iscsi_target_initiator_initiators
         $temp | Add-Member -MemberType NoteProperty -Name "Auth Network" -Value $result.iscsi_target_initiator_auth_network

--- a/Freenas/public/Get-FreeNasIscsiPortal.ps1
+++ b/Freenas/public/Get-FreeNasIscsiPortal.ps1
@@ -14,8 +14,8 @@
 
         $result = Invoke-FreeNasRestMethod -Uri $Uri -Method Get
 
-        $Obj = New-Object System.Collections.ArrayList
-        $temp = New-Object System.Object
+        $Obj = New-Object -TypeName System.Collections.ArrayList
+        $temp = New-Object -TypeName System.Object
         $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value $result.id
         if ($null -eq $result.iscsi_target_portal_ips)
         {

--- a/Freenas/public/Get-FreeNasIscsiSummary.ps1
+++ b/Freenas/public/Get-FreeNasIscsiSummary.ps1
@@ -18,12 +18,12 @@
         New-banner -Text "____________" -Online -FontColor Green
         New-banner -Text "Iscsi Summary" -Online
 
-        Write-Host "Your Freenas Server" -NoNewline
-        Write-Host " $script:SrvFreenas" -NoNewline -ForegroundColor Cyan
-        Write-Host " Iscsi Configuration : "
+        Write-Host -Object "Your Freenas Server" -NoNewline
+        Write-Host -Object " $script:SrvFreenas" -NoNewline -ForegroundColor Cyan
+        Write-Host -Object " Iscsi Configuration : "
         $Conf_Iscsi
 
-        Write-host "The Iscsi Portal : "
+        Write-Host -Object "The Iscsi Portal : "
         Get-FreenasIscsiPortal
 
         $TotalSize = ""
@@ -31,15 +31,15 @@
             [int]$Size = [Math]::Round($Extent_Iscsi[$i].Extent_Size , 2)
             [Int]$TotalSize = $TotalSize + $Size
         }
-        Write-host "The Server have"$($Extent_Iscsi).count"Extent(s) with a total size" -NoNewline
-        Write-Host " $TotalSize " -NoNewline -ForegroundColor Cyan
-        Write-Host "GB"
-        Write-host "The Iscsi Extent Type :"
+        Write-Host -Object "The Server have"$($Extent_Iscsi).count"Extent(s) with a total size" -NoNewline
+        Write-Host -Object " $TotalSize " -NoNewline -ForegroundColor Cyan
+        Write-Host -Object "GB"
+        Write-Host -Object "The Iscsi Extent Type :"
         $Extent_Iscsi | FT
-        Write-host "The Target Iscsi :"
+        Write-Host -Object "The Target Iscsi :"
 
         $Target_Iscsi | ft
-        Write-host "The Association Target with Extend :"
+        Write-Host -Object "The Association Target with Extend :"
 
         $Association | ft
     }

--- a/Freenas/public/Get-FreeNasIscsiTarget.ps1
+++ b/Freenas/public/Get-FreeNasIscsiTarget.ps1
@@ -14,10 +14,10 @@
 
         $result = Invoke-FreeNasRestMethod -Uri $Uri -Method Get
 
-        $FreenasIscsiTarget = New-Object System.Collections.ArrayList
+        $FreenasIscsiTarget = New-Object -TypeName System.Collections.ArrayList
         for ($i = 0; $i -lt $result.Count; $i++)
         {
-            $temp = New-Object System.Object
+            $temp = New-Object -TypeName System.Object
             $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value "$($result[$i].Id)"
             $temp | Add-Member -MemberType NoteProperty -Name "Target_Alias" -Value "$($result[$i].iscsi_target_alias)"
             $temp | Add-Member -MemberType NoteProperty -Name "Target_Name" -Value "$($result[$i].iscsi_target_name)"

--- a/Freenas/public/Get-FreeNasSystemAdvanced.ps1
+++ b/Freenas/public/Get-FreeNasSystemAdvanced.ps1
@@ -25,6 +25,6 @@ function Get-FreeNasSystemAdvanced
             Advanced_Serial_port    = ($Info.adv_serialport)
             Advanced_Serial_speed   = ($Info.adv_serialspeed)
 
-        } | fl
+        }
     }
 }

--- a/Freenas/public/Get-FreeNasSystemAlert.ps1
+++ b/Freenas/public/Get-FreeNasSystemAlert.ps1
@@ -10,19 +10,21 @@ Level     : OK
 Message   : The volume tank (ZFS) status is HEALTHY
 Dismissed : false
 #>
-function Get-FreeNasSystemAlert {
+function Get-FreeNasSystemAlert
+{
     Param( )
 
     $Uri = "api/v1.0/system/alert/"
 
     $results = Invoke-FreeNasRestMethod -Uri $Uri -Method Get
 
-    foreach ($Alert in $results) {
+    foreach ($Alert in $results)
+    {
         [PSCustomObject]@{
             Id        = ($Alert.id)
             Level     = ($Alert.level)
             Message   = ($Alert.message)
             Dismissed = ($Alert.dismissed)
-        } | fl
+        }
     }
 }

--- a/Freenas/public/Get-FreeNasSystemEmail.ps1
+++ b/Freenas/public/Get-FreeNasSystemEmail.ps1
@@ -29,7 +29,7 @@
         $FreeNasConf.Add($temp) | Out-Null
 
 
-        return $FreeNasConf | fl
+        return $FreeNasConf
 
 
     }

--- a/Freenas/public/Get-FreeNasSystemEmail.ps1
+++ b/Freenas/public/Get-FreeNasSystemEmail.ps1
@@ -14,7 +14,7 @@
 
         $result = Invoke-FreeNasRestMethod -Uri $Uri -Method Get
 
-        $FreeNasConf = New-Object System.Collections.ArrayList
+        $FreeNasConf = New-Object -TypeName System.Collections.ArrayList
 
         $temp = New-Object PSObject
         $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value $result.id

--- a/Freenas/public/Get-FreeNasSystemEmail.ps1
+++ b/Freenas/public/Get-FreeNasSystemEmail.ps1
@@ -16,7 +16,7 @@
 
         $FreeNasConf = New-Object -TypeName System.Collections.ArrayList
 
-        $temp = New-Object PSObject
+        $temp = New-Object -TypeName PSObject
         $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value $result.id
         $temp | Add-Member -MemberType NoteProperty -Name "From_Email" -Value $result.em_fromemail
         $temp | Add-Member -MemberType NoteProperty -Name "Outgoing_Mail_Server" -Value $result.em_outgoingserver

--- a/Freenas/public/Get-FreeNasSystemNTP.ps1
+++ b/Freenas/public/Get-FreeNasSystemNTP.ps1
@@ -14,11 +14,11 @@
 
         $result = Invoke-FreeNasRestMethod -Uri $Uri -Method Get
 
-        $FreenasConf = New-Object System.Collections.ArrayList
+        $FreenasConf = New-Object -TypeName System.Collections.ArrayList
         for ($i = 0; $i -lt $result.Count; $i++)
         {
 
-            $temp = New-Object System.Object
+            $temp = New-Object -TypeName System.Object
             $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value "$($result[$i].id)"
             $temp | Add-Member -MemberType NoteProperty -Name "NTP_Server" -Value "$($result[$i].ntp_address)"
             $temp | Add-Member -MemberType NoteProperty -Name "NTP_Burst" -Value "$($result[$i].ntp_burst)"

--- a/Freenas/public/Get-FreeNasVolume.ps1
+++ b/Freenas/public/Get-FreeNasVolume.ps1
@@ -17,11 +17,11 @@
     }
     End
     {
-        $FreenasVolume = New-Object System.Collections.ArrayList
+        $FreenasVolume = New-Object -TypeName System.Collections.ArrayList
 
         if ($null -eq $result.count)
         {
-            $temp = New-Object System.Object
+            $temp = New-Object -TypeName System.Object
             $temp | Add-Member -MemberType NoteProperty -Name "Name" -Value "$($result.Name)"
             $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value "$($result.Id)"
             $temp | Add-Member -MemberType NoteProperty -Name "MountPoint" -Value "$($result.mountpoint)"
@@ -36,7 +36,7 @@
         {
             for ($i = 0; $i -lt $result.Count; $i++)
             {
-                $temp = New-Object System.Object
+                $temp = New-Object -TypeName System.Object
                 $temp | Add-Member -MemberType NoteProperty -Name "Name" -Value "$($result[$i].Name)"
                 $temp | Add-Member -MemberType NoteProperty -Name "Id" -Value "$($result[$i].Id)"
                 $temp | Add-Member -MemberType NoteProperty -Name "MountPoint" -Value "$($result[$i].mountpoint)"

--- a/Freenas/public/Get-FreeNasZvol.ps1
+++ b/Freenas/public/Get-FreeNasZvol.ps1
@@ -24,11 +24,11 @@
     }
     End
     {
-        $ZVolume = New-Object System.Collections.ArrayList
+        $ZVolume = New-Object -TypeName System.Collections.ArrayList
 
         if ($null -eq $result.count)
         {
-            $temp = New-Object System.Object
+            $temp = New-Object -TypeName System.Object
             $temp | Add-Member -MemberType NoteProperty -Name "Name" -Value "$($result.Name)"
             $temp | Add-Member -MemberType NoteProperty -Name "Comments" -Value "$($result.comments)"
             $temp | Add-Member -MemberType NoteProperty -Name "Deduplication" -Value "$($result.dedup)"
@@ -45,7 +45,7 @@
 
             for ($i = 0; $i -lt $result.Count; $i++)
             {
-                $temp = New-Object System.Object
+                $temp = New-Object -TypeName System.Object
                 $temp | Add-Member -MemberType NoteProperty -Name "Name" -Value "$($result[$i].Name)"
                 $temp | Add-Member -MemberType NoteProperty -Name "Comments" -Value "$($result[$i].comments)"
                 $temp | Add-Member -MemberType NoteProperty -Name "Deduplication" -Value "$($result[$i].dedup)"

--- a/Freenas/public/Get-PowerShellVersion.ps1
+++ b/Freenas/public/Get-PowerShellVersion.ps1
@@ -12,6 +12,6 @@ function Get-PowerShellVersion {
    ()
 
    $Script:Version = $PSVersionTable.PSVersion.Major
-   Write-Verbose "The module is running in Powershell $Version "
+   Write-Verbose -Message "The module is running in Powershell $Version "
 
 }

--- a/Freenas/public/New-FreeNasVolume.ps1
+++ b/Freenas/public/New-FreeNasVolume.ps1
@@ -38,7 +38,8 @@
 
         $FreenasVolume = @()
 
-        $StartDisksNB..$($StartDisksNB + $NbDisks - 1) | Foreach-Object { $freenasvolume += "$DiskNamebase$_" }
+        $StartDisksNB..$($StartDisksNB + $NbDisks - 1) |
+        Foreach-Object -Process { $freenasvolume += "$DiskNamebase$_" }
 
         $Uri = "api/v1.0/storage/volume/"
 

--- a/Freenas/public/Update-FreeNasInterface.ps1
+++ b/Freenas/public/Update-FreeNasInterface.ps1
@@ -25,7 +25,7 @@ function Update-FreeNasInterface
         $Uri = "api/v1.0/network/interface/$Id/"
         $Obj = new-Object -TypeName PSObject
 
-        Write-verbose "Detect DHCP status"
+        Write-Verbose -Message "Detect DHCP status"
         $Dhcp = Get-FreeNasInterface
 
         switch ($Dhcp.Dhcp)
@@ -54,7 +54,7 @@ function Update-FreeNasInterface
     {
 
         $response = Invoke-FreeNasRestMethod -method Put -body $Obj -Uri $Uri
-        Write-Warning "You need to reconnect to the host $Ipv4/$NetMask"
+        Write-Warning -Message "You need to reconnect to the host $Ipv4/$NetMask"
 
     }
 


### PR DESCRIPTION
Remove `fl` on some functions.
This is bad practice to format the output using `format-*`.
You might want to use PSTypeName instead to manage the output view